### PR TITLE
[Upstream] fix: add arm64 platform

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: ${{ contains(github.ref, 'alpha') && 'linux/amd64' || 'linux/amd64' }}
+          platforms: ${{ contains(github.ref, 'alpha') && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2216

close #2053  #2162 #1202 

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
