### PR TITLE
[Upstream] feature: xunfeiv2 support x1

### DIFF
--- a/relay/adaptor/openai/adaptor.go
+++ b/relay/adaptor/openai/adaptor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/songquanpeng/one-api/relay/adaptor/geminiv2"
 	"github.com/songquanpeng/one-api/relay/adaptor/minimax"
 	"github.com/songquanpeng/one-api/relay/adaptor/novita"
+	"github.com/songquanpeng/one-api/relay/adaptor/xunfeiv2"
 	"github.com/songquanpeng/one-api/relay/channeltype"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
@@ -62,6 +63,8 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 		return alibailian.GetRequestURL(meta)
 	case channeltype.GeminiOpenAICompatible:
 		return geminiv2.GetRequestURL(meta)
+	case channeltype.XunfeiV2:
+		return xunfeiv2.GetRequestURL(meta)
 	default:
 		return GetFullRequestURL(meta.BaseURL, meta.RequestURLPath, meta.ChannelType), nil
 	}

--- a/relay/adaptor/xunfeiv2/constants.go
+++ b/relay/adaptor/xunfeiv2/constants.go
@@ -9,4 +9,5 @@ var ModelList = []string{
 	"generalv3.5",
 	"max-32k",
 	"4.0Ultra",
+	"x1",
 }

--- a/relay/adaptor/xunfeiv2/main.go
+++ b/relay/adaptor/xunfeiv2/main.go
@@ -1,0 +1,16 @@
+package xunfeiv2
+
+import (
+	"fmt"
+
+	"github.com/songquanpeng/one-api/relay/meta"
+)
+
+func GetRequestURL(meta *meta.Meta) (string, error) {
+	switch meta.ActualModelName {
+	case "x1":
+		return fmt.Sprintf("%s/v2/chat/completions", meta.BaseURL), nil
+	default:
+	}
+	return fmt.Sprintf("%s/v2/chat/completions", meta.BaseURL), nil
+}


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2247

讯飞V2 支持 x1
我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/17153f65-f638-4e6b-880f-0d5a243fc51d)
![image](https://github.com/user-attachments/assets/1c153e6e-f4b8-4bdd-b930-4efcb85055ad)

