### PR TITLE
[Upstream] feat: 增加vertex embedding的支持，修改vertex的模型adapter匹配逻辑

### DIFF
--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -435,3 +435,17 @@ func EmbeddingHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStat
 	_, err = c.Writer.Write(jsonResponse)
 	return nil, &fullTextResponse.Usage
 }
+
+func EmbeddingResponseHandler(c *gin.Context, statusCode int, resp *openai.EmbeddingResponse) (*model.ErrorWithStatusCode, *model.Usage) {
+	jsonResponse, err := json.Marshal(resp)
+	if err != nil {
+		return openai.ErrorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(statusCode)
+	_, err = c.Writer.Write(jsonResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "write_response_body_failed", http.StatusInternalServerError), nil
+	}
+	return nil, &resp.Usage
+}

--- a/relay/adaptor/vertexai/adaptor.go
+++ b/relay/adaptor/vertexai/adaptor.go
@@ -61,12 +61,15 @@ func (a *Adaptor) GetChannelName() string {
 
 func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	suffix := ""
-	if strings.HasPrefix(meta.ActualModelName, "gemini") {
+	modelType := PredictModelType(meta.ActualModelName)
+	if modelType == VertexAIGemini {
 		if meta.IsStream {
 			suffix = "streamGenerateContent?alt=sse"
 		} else {
 			suffix = "generateContent"
 		}
+	} else if modelType == VertexAIEmbedding {
+		suffix = "predict"
 	} else {
 		if meta.IsStream {
 			suffix = "streamRawPredict?alt=sse"
@@ -114,4 +117,14 @@ func (a *Adaptor) ConvertImageRequest(request *model.ImageRequest) (any, error) 
 
 func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Reader) (*http.Response, error) {
 	return channelhelper.DoRequestHelper(a, c, meta, requestBody)
+}
+
+func PredictModelType(model string) VertexAIModelType {
+	if strings.HasPrefix(model, "gemini-") {
+		return VertexAIGemini
+	}
+	if strings.HasPrefix(model, "text-embedding") || strings.HasPrefix(model, "text-multilingual-embedding") {
+		return VertexAIEmbedding
+	}
+	return VertexAIClaude
 }

--- a/relay/adaptor/vertexai/embedding/adapter.go
+++ b/relay/adaptor/vertexai/embedding/adapter.go
@@ -1,0 +1,107 @@
+package vertexai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/songquanpeng/one-api/relay/adaptor/gemini"
+	"github.com/songquanpeng/one-api/relay/adaptor/openai"
+	model2 "github.com/songquanpeng/one-api/relay/adaptor/vertexai/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+var ModelList = []string{
+	"textembedding-gecko-multilingual@001", "text-multilingual-embedding-002",
+}
+
+type Adaptor struct {
+	model string
+	task  EmbeddingTaskType
+}
+
+var _ model2.InnerAIAdapter = (*Adaptor)(nil)
+
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	inputs := request.ParseInput()
+	if len(inputs) == 0 {
+		return nil, errors.New("request is nil")
+	}
+	parts := strings.Split(request.Model, "|")
+	if len(parts) >= 2 {
+		a.task = EmbeddingTaskType(parts[1])
+	} else {
+		a.task = EmbeddingTaskTypeSemanticSimilarity
+	}
+	a.model = parts[0]
+	instances := make([]EmbeddingInstance, len(inputs))
+	for i, input := range inputs {
+		instances[i] = EmbeddingInstance{
+			Content:  input,
+			TaskType: a.task,
+		}
+	}
+
+	embeddingRequest := EmbeddingRequest{
+		Instances: instances,
+		Parameters: EmbeddingParams{
+			OutputDimensionality: request.Dimensions,
+		},
+	}
+
+	return embeddingRequest, nil
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	err, usage = EmbeddingHandler(c, a.model, resp)
+	return
+}
+
+func EmbeddingHandler(c *gin.Context, modelName string, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
+	var vertexEmbeddingResponse EmbeddingResponse
+	responseBody, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if err != nil {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return openai.ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = json.Unmarshal(responseBody, &vertexEmbeddingResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	openaiResp := &openai.EmbeddingResponse{
+		Model: modelName,
+		Data:  make([]openai.EmbeddingResponseItem, 0, len(vertexEmbeddingResponse.Predictions)),
+		Usage: model.Usage{
+			TotalTokens: 0,
+		},
+	}
+
+	for i, pred := range vertexEmbeddingResponse.Predictions {
+		openaiResp.Data = append(openaiResp.Data, openai.EmbeddingResponseItem{
+			Index:     i,
+			Embedding: pred.Embeddings.Values,
+		})
+	}
+
+	for _, pred := range vertexEmbeddingResponse.Predictions {
+		openaiResp.Usage.TotalTokens += pred.Embeddings.Statistics.TokenCount
+	}
+
+	return gemini.EmbeddingResponseHandler(c, resp.StatusCode, openaiResp)
+}

--- a/relay/adaptor/vertexai/embedding/model.go
+++ b/relay/adaptor/vertexai/embedding/model.go
@@ -1,0 +1,45 @@
+package vertexai
+
+type EmbeddingTaskType string
+
+const (
+	EmbeddingTaskTypeRetrievalQuery     EmbeddingTaskType = "RETRIEVAL_QUERY"
+	EmbeddingTaskTypeRetrievalDocument  EmbeddingTaskType = "RETRIEVAL_DOCUMENT"
+	EmbeddingTaskTypeSemanticSimilarity EmbeddingTaskType = "SEMANTIC_SIMILARITY"
+	EmbeddingTaskTypeClassification     EmbeddingTaskType = "CLASSIFICATION"
+	EmbeddingTaskTypeClustering         EmbeddingTaskType = "CLUSTERING"
+	EmbeddingTaskTypeQuestionAnswering  EmbeddingTaskType = "QUESTION_ANSWERING"
+	EmbeddingTaskTypeFactVerification   EmbeddingTaskType = "FACT_VERIFICATION"
+	EmbeddingTaskTypeCodeRetrievalQuery EmbeddingTaskType = "CODE_RETRIEVAL_QUERY"
+)
+
+type EmbeddingRequest struct {
+	Instances  []EmbeddingInstance `json:"instances"`
+	Parameters EmbeddingParams     `json:"parameters"`
+}
+
+type EmbeddingInstance struct {
+	Content  string            `json:"content"`
+	TaskType EmbeddingTaskType `json:"task_type,omitempty"`
+	Title    string            `json:"title,omitempty"`
+}
+
+type EmbeddingParams struct {
+	AutoTruncate         bool `json:"autoTruncate,omitempty"`
+	OutputDimensionality int  `json:"outputDimensionality,omitempty"`
+	// Texts                []string `json:"texts,omitempty"`
+}
+
+type EmbeddingResponse struct {
+	Predictions []struct {
+		Embeddings EmbeddingData `json:"embeddings"`
+	} `json:"predictions"`
+}
+
+type EmbeddingData struct {
+	Statistics struct {
+		Truncated  bool `json:"truncated"`
+		TokenCount int  `json:"token_count"`
+	} `json:"statistics"`
+	Values []float64 `json:"values"`
+}

--- a/relay/adaptor/vertexai/model/model.go
+++ b/relay/adaptor/vertexai/model/model.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+	"net/http"
+)
+
+type InnerAIAdapter interface {
+	ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error)
+	DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode)
+}


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2267

Feature:
1. 改动VertexAI的GetAdaptor逻辑，default增加模型adapter的逻辑，便于适配后续新模型产生
2. 增加VertexAI的Embedding的adapter，支持VertexAI的embedding api

我已确认该 PR 已自测通过，相关截图如下：


![image](https://github.com/user-attachments/assets/76f78019-8020-4973-bb82-e2f9b82c061c)

