### PR TITLE
[Upstream] 给model.Error.Message赋值

### DIFF
--- a/relay/controller/error.go
+++ b/relay/controller/error.go
@@ -66,7 +66,7 @@ func RelayErrorHandler(resp *http.Response) (ErrorWithStatusCode *model.ErrorWit
 	ErrorWithStatusCode = &model.ErrorWithStatusCode{
 		StatusCode: resp.StatusCode,
 		Error: model.Error{
-			Message: "",
+			Message: resp.Status,
 			Type:    "upstream_error",
 			Code:    "bad_response_status_code",
 			Param:   strconv.Itoa(resp.StatusCode),


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2275

比如调用方没有设置Content-Type，deepseek的resp.Status存有错误描述：415 Unsupported Media Type。这个pr之后可以在调用端得到更明显的错误提示：{"message":"415 Unsupported Media Type","type":"upstream_error","param":"415","code":"bad_response_status_code"}  有利于排错。
