### PR TITLE
[Upstream] fix: invalidate group_models Redis cache on channel create/update/delete

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -67,11 +67,19 @@ func (channel *Channel) AddAbilities() error {
 			abilities = append(abilities, ability)
 		}
 	}
-	return DB.Create(&abilities).Error
+	err := DB.Create(&abilities).Error
+	if err == nil {
+		ClearGroupModelsCacheByGroups(groups_)
+	}
+	return err
 }
 
 func (channel *Channel) DeleteAbilities() error {
-	return DB.Where("channel_id = ?", channel.Id).Delete(&Ability{}).Error
+	err := DB.Where("channel_id = ?", channel.Id).Delete(&Ability{}).Error
+	if err == nil {
+		ClearGroupModelsCacheByGroups(strings.Split(channel.Group, ","))
+	}
+	return err
 }
 
 // UpdateAbilities updates abilities of this channel.

--- a/model/cache.go
+++ b/model/cache.go
@@ -167,6 +167,23 @@ func CacheGetGroupModels(ctx context.Context, group string) ([]string, error) {
 	return models, nil
 }
 
+// ClearGroupModelsCacheByGroups deletes the cached group model lists for the
+// given group names so the next query fetches fresh data from the database.
+func ClearGroupModelsCacheByGroups(groups []string) {
+	if !common.RedisEnabled {
+		return
+	}
+	for _, group := range groups {
+		if group == "" {
+			continue
+		}
+		err := common.RedisDel(fmt.Sprintf("group_models:%s", group))
+		if err != nil {
+			logger.SysError(fmt.Sprintf("Redis delete group_models cache error for group %s: %s", group, err.Error()))
+		}
+	}
+}
+
 var group2model2channels map[string]map[string][]*Channel
 var channelSyncLock sync.RWMutex
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -3,7 +3,9 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/helper"
 	"github.com/songquanpeng/one-api/common/logger"
@@ -195,6 +197,15 @@ func UpdateChannelStatusById(id int, status int) {
 	err = DB.Model(&Channel{}).Where("id = ?", id).Update("status", status).Error
 	if err != nil {
 		logger.SysError("failed to update channel status: " + err.Error())
+	}
+	// Invalidate the group models cache so users immediately see the updated model list.
+	groupCol := "`group`"
+	if common.UsingPostgreSQL {
+		groupCol = `"group"`
+	}
+	var groupStr string
+	if dbErr := DB.Model(&Channel{}).Where("id = ?", id).Select(groupCol).Pluck(groupCol, &groupStr).Error; dbErr == nil && groupStr != "" {
+		ClearGroupModelsCacheByGroups(strings.Split(groupStr, ","))
 	}
 }
 


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2381

Fixes #2327

## Problem

When a channel is created, updated, or its enabled/disabled status is changed, the Redis `group_models:{group}` cache key is not invalidated. Because this cache has a TTL equal to `SYNC_FREQUENCY` (default 10 minutes), users who create a new channel must wait up to 10 minutes before the channel's models appear in the token model-scope selector (`/api/user/available_models`). During this time, searching for the newly added model (e.g. `gemini-2.5-pro`) returns no results in the dropdown.

## Solution

Add `ClearGroupModelsCacheByGroups(groups []string)` to `model/cache.go` that deletes the relevant Redis keys for the affected groups. Call it:

- In `AddAbilities()` after successfully inserting ability rows (channel create)
- In `DeleteAbilities()` after successfully deleting ability rows (channel delete / update)
- In `UpdateChannelStatusById()` after changing channel status (channel enable/disable)

`UpdateAbilities()` already delegates to `DeleteAbilities` + `AddAbilities`, so channel updates are covered automatically.

No-op when Redis is not enabled.

## Testing

- Reproduced by: create a channel, immediately query `/api/user/available_models` — with the fix the new model appears immediately; without it the old cache is still returned.
- Build verified: `go build ./...` succeeds.