### PR TITLE
[Upstream] fix: return total count from paginated list APIs for accurate pagination

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -23,10 +23,19 @@ func GetAllChannels(c *gin.Context) {
 		})
 		return
 	}
+	total, err := model.CountChannels()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    channels,
+		"total":   total,
 	})
 	return
 }

--- a/controller/log.go
+++ b/controller/log.go
@@ -29,10 +29,19 @@ func GetAllLogs(c *gin.Context) {
 		})
 		return
 	}
+	total, err := model.CountAllLogs(logType, startTimestamp, endTimestamp, modelName, username, tokenName, channel)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    logs,
+		"total":   total,
 	})
 	return
 }
@@ -56,10 +65,19 @@ func GetUserLogs(c *gin.Context) {
 		})
 		return
 	}
+	total, err := model.CountUserLogs(userId, logType, startTimestamp, endTimestamp, modelName, tokenName)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    logs,
+		"total":   total,
 	})
 	return
 }

--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -24,10 +24,19 @@ func GetAllRedemptions(c *gin.Context) {
 		})
 		return
 	}
+	total, err := model.CountRedemptions()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    redemptions,
+		"total":   total,
 	})
 	return
 }

--- a/controller/token.go
+++ b/controller/token.go
@@ -30,10 +30,21 @@ func GetAllTokens(c *gin.Context) {
 		})
 		return
 	}
+
+	total, err := model.CountUserTokens(userId)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    tokens,
+		"total":   total,
 	})
 	return
 }

--- a/controller/user.go
+++ b/controller/user.go
@@ -201,10 +201,20 @@ func GetAllUsers(c *gin.Context) {
 		return
 	}
 
+	total, err := model.CountUsers()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    users,
+		"total":   total,
 	})
 }
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -66,6 +66,12 @@ func GetAllChannels(startIdx int, num int, scope string) ([]*Channel, error) {
 	return channels, err
 }
 
+func CountChannels() (int64, error) {
+	var count int64
+	err := DB.Model(&Channel{}).Count(&count).Error
+	return count, err
+}
+
 func SearchChannels(keyword string) (channels []*Channel, err error) {
 	err = DB.Omit("key").Where("id = ? or name LIKE ?", helper.String2Int(keyword), keyword+"%").Find(&channels).Error
 	return channels, err

--- a/model/log.go
+++ b/model/log.go
@@ -122,6 +122,36 @@ func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName
 	return logs, err
 }
 
+func CountAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, channel int) (int64, error) {
+	var tx *gorm.DB
+	if logType == LogTypeUnknown {
+		tx = LOG_DB.Model(&Log{})
+	} else {
+		tx = LOG_DB.Model(&Log{}).Where("type = ?", logType)
+	}
+	if modelName != "" {
+		tx = tx.Where("model_name = ?", modelName)
+	}
+	if username != "" {
+		tx = tx.Where("username = ?", username)
+	}
+	if tokenName != "" {
+		tx = tx.Where("token_name = ?", tokenName)
+	}
+	if startTimestamp != 0 {
+		tx = tx.Where("created_at >= ?", startTimestamp)
+	}
+	if endTimestamp != 0 {
+		tx = tx.Where("created_at <= ?", endTimestamp)
+	}
+	if channel != 0 {
+		tx = tx.Where("channel_id = ?", channel)
+	}
+	var count int64
+	err := tx.Count(&count).Error
+	return count, err
+}
+
 func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int64, modelName string, tokenName string, startIdx int, num int) (logs []*Log, err error) {
 	var tx *gorm.DB
 	if logType == LogTypeUnknown {
@@ -143,6 +173,30 @@ func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int
 	}
 	err = tx.Order("id desc").Limit(num).Offset(startIdx).Omit("id").Find(&logs).Error
 	return logs, err
+}
+
+func CountUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int64, modelName string, tokenName string) (int64, error) {
+	var tx *gorm.DB
+	if logType == LogTypeUnknown {
+		tx = LOG_DB.Model(&Log{}).Where("user_id = ?", userId)
+	} else {
+		tx = LOG_DB.Model(&Log{}).Where("user_id = ? and type = ?", userId, logType)
+	}
+	if modelName != "" {
+		tx = tx.Where("model_name = ?", modelName)
+	}
+	if tokenName != "" {
+		tx = tx.Where("token_name = ?", tokenName)
+	}
+	if startTimestamp != 0 {
+		tx = tx.Where("created_at >= ?", startTimestamp)
+	}
+	if endTimestamp != 0 {
+		tx = tx.Where("created_at <= ?", endTimestamp)
+	}
+	var count int64
+	err := tx.Count(&count).Error
+	return count, err
 }
 
 func SearchAllLogs(keyword string) (logs []*Log, err error) {

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -36,6 +36,12 @@ func GetAllRedemptions(startIdx int, num int) ([]*Redemption, error) {
 	return redemptions, err
 }
 
+func CountRedemptions() (int64, error) {
+	var count int64
+	err := DB.Model(&Redemption{}).Count(&count).Error
+	return count, err
+}
+
 func SearchRedemptions(keyword string) (redemptions []*Redemption, err error) {
 	err = DB.Where("id = ? or name LIKE ?", keyword, keyword+"%").Find(&redemptions).Error
 	return redemptions, err

--- a/model/token.go
+++ b/model/token.go
@@ -54,6 +54,12 @@ func GetAllUserTokens(userId int, startIdx int, num int, order string) ([]*Token
 	return tokens, err
 }
 
+func CountUserTokens(userId int) (int64, error) {
+	var count int64
+	err := DB.Model(&Token{}).Where("user_id = ?", userId).Count(&count).Error
+	return count, err
+}
+
 func SearchUserTokens(userId int, keyword string) (tokens []*Token, err error) {
 	err = DB.Where("user_id = ?", userId).Where("name LIKE ?", keyword+"%").Find(&tokens).Error
 	return tokens, err

--- a/model/user.go
+++ b/model/user.go
@@ -77,6 +77,12 @@ func GetAllUsers(startIdx int, num int, order string) (users []*User, err error)
 	return users, err
 }
 
+func CountUsers() (int64, error) {
+	var count int64
+	err := DB.Model(&User{}).Where("status != ?", UserStatusDeleted).Count(&count).Error
+	return count, err
+}
+
 func SearchUsers(keyword string) (users []*User, err error) {
 	if !common.UsingPostgreSQL {
 		err = DB.Omit("password").Where("id = ? or username LIKE ? or email LIKE ? or display_name LIKE ?", keyword, keyword+"%", keyword+"%", keyword+"%").Find(&users).Error

--- a/web/berry/src/views/Channel/index.js
+++ b/web/berry/src/views/Channel/index.js
@@ -28,6 +28,7 @@ export default function ChannelPage() {
   const [activePage, setActivePage] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [channelCount, setChannelCount] = useState(0);
   const theme = useTheme();
   const matchUpMd = useMediaQuery(theme.breakpoints.up('sm'));
   const [openModal, setOpenModal] = useState(false);
@@ -36,7 +37,7 @@ export default function ChannelPage() {
   const loadChannels = async (startIdx) => {
     setSearching(true);
     const res = await API.get(`/api/channel/?p=${startIdx}`);
-    const { success, message, data } = res.data;
+    const { success, message, data, total } = res.data;
     if (success) {
       if (startIdx === 0) {
         setChannels(data);
@@ -45,19 +46,24 @@ export default function ChannelPage() {
         newChannels.splice(startIdx * ITEMS_PER_PAGE, data.length, ...data);
         setChannels(newChannels);
       }
+      if (total !== undefined) {
+        setChannelCount(total);
+      }
     } else {
       showError(message);
     }
     setSearching(false);
   };
 
-  const onPaginationChange = (event, activePage) => {
+  const onPaginationChange = (event, newPage) => {
     (async () => {
-      if (activePage === Math.ceil(channels.length / ITEMS_PER_PAGE)) {
-        // In this case we have to load more data and then append them.
-        await loadChannels(activePage);
+      const pageStart = newPage * ITEMS_PER_PAGE;
+      const pageEnd = pageStart + ITEMS_PER_PAGE;
+      if (channels.slice(pageStart, pageEnd).length < ITEMS_PER_PAGE && pageStart < channelCount) {
+        // Page data not yet loaded, fetch it from the backend.
+        await loadChannels(newPage);
       }
-      setActivePage(activePage);
+      setActivePage(newPage);
     })();
   };
 
@@ -73,6 +79,7 @@ export default function ChannelPage() {
     const { success, message, data } = res.data;
     if (success) {
       setChannels(data);
+      setChannelCount(data.length);
       setActivePage(0);
     } else {
       showError(message);
@@ -274,7 +281,7 @@ export default function ChannelPage() {
         <TablePagination
           page={activePage}
           component="div"
-          count={channels.length + (channels.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
+          count={channelCount}
           rowsPerPage={ITEMS_PER_PAGE}
           onPageChange={onPaginationChange}
           rowsPerPageOptions={[ITEMS_PER_PAGE]}

--- a/web/berry/src/views/Log/index.js
+++ b/web/berry/src/views/Log/index.js
@@ -34,6 +34,7 @@ export default function Log() {
   const [activePage, setActivePage] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState(originalKeyword);
+  const [logCount, setLogCount] = useState(0);
   const [initPage, setInitPage] = useState(true);
   const userIsAdmin = isAdmin();
 
@@ -48,7 +49,7 @@ export default function Log() {
       delete query.channel;
     }
     const res = await API.get(url, { params: query });
-    const { success, message, data } = res.data;
+    const { success, message, data, total } = res.data;
     if (success) {
       if (startIdx === 0) {
         setLogs(data);
@@ -57,19 +58,24 @@ export default function Log() {
         newLogs.splice(startIdx * ITEMS_PER_PAGE, data.length, ...data);
         setLogs(newLogs);
       }
+      if (total !== undefined) {
+        setLogCount(total);
+      }
     } else {
       showError(message);
     }
     setSearching(false);
   };
 
-  const onPaginationChange = (event, activePage) => {
+  const onPaginationChange = (event, newPage) => {
     (async () => {
-      if (activePage === Math.ceil(logs.length / ITEMS_PER_PAGE)) {
-        // In this case we have to load more data and then append them.
-        await loadLogs(activePage);
+      const pageStart = newPage * ITEMS_PER_PAGE;
+      const pageEnd = pageStart + ITEMS_PER_PAGE;
+      if (logs.slice(pageStart, pageEnd).length < ITEMS_PER_PAGE && pageStart < logCount) {
+        // Page data not yet loaded, fetch it from the backend.
+        await loadLogs(newPage);
       }
-      setActivePage(activePage);
+      setActivePage(newPage);
     })();
   };
 
@@ -146,7 +152,7 @@ export default function Log() {
         <TablePagination
           page={activePage}
           component="div"
-          count={logs.length + (logs.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
+          count={logCount}
           rowsPerPage={ITEMS_PER_PAGE}
           onPageChange={onPaginationChange}
           rowsPerPageOptions={[ITEMS_PER_PAGE]}

--- a/web/berry/src/views/Redemption/index.js
+++ b/web/berry/src/views/Redemption/index.js
@@ -25,13 +25,14 @@ export default function Redemption() {
   const [activePage, setActivePage] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [redemptionCount, setRedemptionCount] = useState(0);
   const [openModal, setOpenModal] = useState(false);
   const [editRedemptionId, setEditRedemptionId] = useState(0);
 
   const loadRedemptions = async (startIdx) => {
     setSearching(true);
     const res = await API.get(`/api/redemption/?p=${startIdx}`);
-    const { success, message, data } = res.data;
+    const { success, message, data, total } = res.data;
     if (success) {
       if (startIdx === 0) {
         setRedemptions(data);
@@ -40,19 +41,24 @@ export default function Redemption() {
         newRedemptions.splice(startIdx * ITEMS_PER_PAGE, data.length, ...data);
         setRedemptions(newRedemptions);
       }
+      if (total !== undefined) {
+        setRedemptionCount(total);
+      }
     } else {
       showError(message);
     }
     setSearching(false);
   };
 
-  const onPaginationChange = (event, activePage) => {
+  const onPaginationChange = (event, newPage) => {
     (async () => {
-      if (activePage === Math.ceil(redemptions.length / ITEMS_PER_PAGE)) {
-        // In this case we have to load more data and then append them.
-        await loadRedemptions(activePage);
+      const pageStart = newPage * ITEMS_PER_PAGE;
+      const pageEnd = pageStart + ITEMS_PER_PAGE;
+      if (redemptions.slice(pageStart, pageEnd).length < ITEMS_PER_PAGE && pageStart < redemptionCount) {
+        // Page data not yet loaded, fetch it from the backend.
+        await loadRedemptions(newPage);
       }
-      setActivePage(activePage);
+      setActivePage(newPage);
     })();
   };
 
@@ -68,6 +74,7 @@ export default function Redemption() {
     const { success, message, data } = res.data;
     if (success) {
       setRedemptions(data);
+      setRedemptionCount(data.length);
       setActivePage(0);
     } else {
       showError(message);
@@ -191,7 +198,7 @@ export default function Redemption() {
         <TablePagination
           page={activePage}
           component="div"
-          count={redemptions.length + (redemptions.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
+          count={redemptionCount}
           rowsPerPage={ITEMS_PER_PAGE}
           onPageChange={onPaginationChange}
           rowsPerPageOptions={[ITEMS_PER_PAGE]}

--- a/web/berry/src/views/Token/index.js
+++ b/web/berry/src/views/Token/index.js
@@ -26,6 +26,7 @@ export default function Token() {
   const [activePage, setActivePage] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [tokenCount, setTokenCount] = useState(0);
   const [openModal, setOpenModal] = useState(false);
   const [editTokenId, setEditTokenId] = useState(0);
   const siteInfo = useSelector((state) => state.siteInfo);
@@ -33,7 +34,7 @@ export default function Token() {
   const loadTokens = async (startIdx) => {
     setSearching(true);
     const res = await API.get(`/api/token/?p=${startIdx}`);
-    const { success, message, data } = res.data;
+    const { success, message, data, total } = res.data;
     if (success) {
       if (startIdx === 0) {
         setTokens(data);
@@ -41,6 +42,9 @@ export default function Token() {
         let newTokens = [...tokens];
         newTokens.splice(startIdx * ITEMS_PER_PAGE, data.length, ...data);
         setTokens(newTokens);
+      }
+      if (total !== undefined) {
+        setTokenCount(total);
       }
     } else {
       showError(message);
@@ -56,13 +60,15 @@ export default function Token() {
       });
   }, []);
 
-  const onPaginationChange = (event, activePage) => {
+  const onPaginationChange = (event, newPage) => {
     (async () => {
-      if (activePage === Math.ceil(tokens.length / ITEMS_PER_PAGE)) {
-        // In this case we have to load more data and then append them.
-        await loadTokens(activePage);
+      const pageStart = newPage * ITEMS_PER_PAGE;
+      const pageEnd = pageStart + ITEMS_PER_PAGE;
+      if (tokens.slice(pageStart, pageEnd).length < ITEMS_PER_PAGE && pageStart < tokenCount) {
+        // Page data not yet loaded, fetch it from the backend.
+        await loadTokens(newPage);
       }
-      setActivePage(activePage);
+      setActivePage(newPage);
     })();
   };
 
@@ -78,6 +84,7 @@ export default function Token() {
     const { success, message, data } = res.data;
     if (success) {
       setTokens(data);
+      setTokenCount(data.length);
       setActivePage(0);
     } else {
       showError(message);
@@ -202,7 +209,7 @@ export default function Token() {
         <TablePagination
           page={activePage}
           component="div"
-          count={tokens.length + (tokens.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
+          count={tokenCount}
           rowsPerPage={ITEMS_PER_PAGE}
           onPageChange={onPaginationChange}
           rowsPerPageOptions={[ITEMS_PER_PAGE]}

--- a/web/berry/src/views/User/index.js
+++ b/web/berry/src/views/User/index.js
@@ -25,13 +25,14 @@ export default function Users() {
   const [activePage, setActivePage] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [userCount, setUserCount] = useState(0);
   const [openModal, setOpenModal] = useState(false);
   const [editUserId, setEditUserId] = useState(0);
 
   const loadUsers = async (startIdx) => {
     setSearching(true);
     const res = await API.get(`/api/user/?p=${startIdx}`);
-    const { success, message, data } = res.data;
+    const { success, message, data, total } = res.data;
     if (success) {
       if (startIdx === 0) {
         setUsers(data);
@@ -40,19 +41,24 @@ export default function Users() {
         newUsers.splice(startIdx * ITEMS_PER_PAGE, data.length, ...data);
         setUsers(newUsers);
       }
+      if (total !== undefined) {
+        setUserCount(total);
+      }
     } else {
       showError(message);
     }
     setSearching(false);
   };
 
-  const onPaginationChange = (event, activePage) => {
+  const onPaginationChange = (event, newPage) => {
     (async () => {
-      if (activePage === Math.ceil(users.length / ITEMS_PER_PAGE)) {
-        // In this case we have to load more data and then append them.
-        await loadUsers(activePage);
+      const pageStart = newPage * ITEMS_PER_PAGE;
+      const pageEnd = pageStart + ITEMS_PER_PAGE;
+      if (users.slice(pageStart, pageEnd).length < ITEMS_PER_PAGE && pageStart < userCount) {
+        // Page data not yet loaded, fetch it from the backend.
+        await loadUsers(newPage);
       }
-      setActivePage(activePage);
+      setActivePage(newPage);
     })();
   };
 
@@ -68,6 +74,7 @@ export default function Users() {
     const { success, message, data } = res.data;
     if (success) {
       setUsers(data);
+      setUserCount(data.length);
       setActivePage(0);
     } else {
       showError(message);
@@ -193,7 +200,7 @@ export default function Users() {
         <TablePagination
           page={activePage}
           component="div"
-          count={users.length + (users.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
+          count={userCount}
           rowsPerPage={ITEMS_PER_PAGE}
           onPageChange={onPaginationChange}
           rowsPerPageOptions={[ITEMS_PER_PAGE]}


### PR DESCRIPTION
Synced from upstream PR: https://github.com/songquanpeng/one-api/pull/2380

Fixes #2338

## Problem

The paginated list endpoints for channels, users, tokens, redemptions, and logs returned only the current page's data without a total record count. The berry-theme frontend inferred the total heuristically:

```js
count={items.length + (items.length % ITEMS_PER_PAGE === 0 ? 1 : 0)}
```

This means that after loading the first page (e.g. 10 items), MUI `TablePagination` received `count = 11`, showing only **2 navigable pages** at a time. Users had to click "Next" repeatedly to reach later pages — they could never jump directly to page 5 or the last page.

## Solution

**Backend** — Add `Count*` functions in the model layer that execute a `SELECT COUNT(*)` with the same filter conditions as the corresponding `Get*` functions:
- `model.CountChannels()`
- `model.CountUsers()`
- `model.CountUserTokens(userId)`
- `model.CountRedemptions()`
- `model.CountAllLogs(...)` (respects all filter params)
- `model.CountUserLogs(...)` (respects all filter params)

Each `GetAll*` controller now runs the count query and includes a `total` field in the JSON response. This change is **backward-compatible** — old clients and other themes simply ignore the new field.

**Frontend (berry theme)** — Each paginated list view:
1. Stores `total` from the API response in a dedicated state variable (`channelCount`, `userCount`, etc.)
2. Passes it directly to `TablePagination`'s `count` prop, making all pages visible immediately
3. Updates `onPaginationChange` to fetch any not-yet-loaded page when the user navigates directly (e.g. jumps from page 1 to page 8)
4. Updates search handlers to set `count = data.length` for search results (which are returned all at once)

## Testing

- Load the channel list with > 10 channels: pagination now shows the correct total pages immediately
- Navigate directly to a page beyond what was initially loaded: the page data is fetched on demand
- Perform a keyword search: pagination reflects the number of search results
- Non-berry themes and existing API consumers are unaffected (they ignore the new `total` field)